### PR TITLE
Add --no-include-email to ECR login

### DIFF
--- a/bin/docker_push.sh
+++ b/bin/docker_push.sh
@@ -4,7 +4,7 @@
 source "${SCRIPTDIR}/../lib/util.sh"
 
 echo "Logging into ECR..."
-AWS_LOGIN=$(runCommand "aws ecr get-login --region $AWS_REGION")
+AWS_LOGIN=$(runCommand "aws ecr get-login --region $AWS_REGION --no-include-email")
 
 if [ "$?" = "0" ]; then
   eval $AWS_LOGIN || exit $?


### PR DESCRIPTION
-e flag is now deprecated which breaks the ECR login and thus all the ECR logins as it seems that ECR finally has updated to newer Docker. `--no-include-email` should fix it.

See https://stackoverflow.com/questions/44722341/docker-login-unknown-shorthand-flag-e